### PR TITLE
fix: Remove DataLogManager from RobotContainer.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -42,12 +42,6 @@ public class Robot extends TimedRobot {
     m_compressor = new Compressor(30, PneumaticsModuleType.REVPH);
     m_compressor.disable();
 
-    // Use a DataLogManager to automatically handle the saving / sharing of logging info
-    DataLogManager.start();
-
-    // Log DriverStation data, including joystick data, so specific error conditions can be
-    // recreated
-    DriverStation.startDataLog(DataLogManager.getLog());
     // Disable joystick warnings, since false positives may be distracting
     DriverStation.silenceJoystickConnectionWarning(true);
   }


### PR DESCRIPTION
`DataLogManager` writes a log of controller inputs to the RoboRio's SD card. Since we have never used these logs, and they negatively impact the lifetime of the RoboRio, as well as adding an additional failure point, we should stop writing these logs.